### PR TITLE
会社情報セクションを追加

### DIFF
--- a/body.html
+++ b/body.html
@@ -104,6 +104,30 @@
     </div>
 </section>
 
+<!-- 会社情報セクション -->
+<section class="company-info" id="about">
+    <div class="container">
+        <h2 data-i18n="company.title">会社情報</h2>
+        <div class="company-content">
+            <div class="company-card">
+                <div class="company-icon">🏢</div>
+                <h3 data-i18n="company.address.title">会社住所</h3>
+                <p data-i18n="company.address.content">〒100-0001<br>東京都千代田区千代田1-1-1<br>千代田ビル10階</p>
+            </div>
+            <div class="company-card">
+                <div class="company-icon">📞</div>
+                <h3 data-i18n="company.contact.title">連絡先</h3>
+                <p data-i18n="company.contact.content">電話: 03-1234-5678<br>FAX: 03-1234-5679<br>Email: info@myshop.co.jp</p>
+            </div>
+            <div class="company-card">
+                <div class="company-icon">📅</div>
+                <h3 data-i18n="company.founded.title">創業時間</h3>
+                <p data-i18n="company.founded.content">2010年4月1日</p>
+            </div>
+        </div>
+    </div>
+</section>
+
 <!-- カートモーダル -->
 <div class="cart-modal" id="cartModal" onclick="closeCartOnBackdrop(event)">
     <div class="cart-content" onclick="event.stopPropagation()">

--- a/index.html
+++ b/index.html
@@ -81,6 +81,21 @@
                     removed: '商品をカートから削除しました',
                     remove: '削除'
                 },
+                company: {
+                    title: '会社情報',
+                    address: {
+                        title: '会社住所',
+                        content: '〒100-0001\n東京都千代田区千代田1-1-1\n千代田ビル10階'
+                    },
+                    contact: {
+                        title: '連絡先',
+                        content: '電話: 03-1234-5678\nFAX: 03-1234-5679\nEmail: info@myshop.co.jp'
+                    },
+                    founded: {
+                        title: '創業時間',
+                        content: '2010年4月1日'
+                    }
+                },
                 footer: {
                     company: {
                         title: '会社情報',
@@ -144,6 +159,21 @@
                     added: 'Item added to cart',
                     removed: 'Item removed from cart',
                     remove: 'Remove'
+                },
+                company: {
+                    title: 'Company Information',
+                    address: {
+                        title: 'Address',
+                        content: '〒100-0001\nChiyoda Building 10F\n1-1-1 Chiyoda, Chiyoda-ku, Tokyo'
+                    },
+                    contact: {
+                        title: 'Contact',
+                        content: 'Phone: 03-1234-5678\nFAX: 03-1234-5679\nEmail: info@myshop.co.jp'
+                    },
+                    founded: {
+                        title: 'Founded',
+                        content: 'April 1, 2010'
+                    }
                 },
                 footer: {
                     company: {

--- a/styles.css
+++ b/styles.css
@@ -144,6 +144,56 @@ nav a:hover {
     }
 }
 
+/* 会社情報セクション */
+.company-info {
+    padding: 4rem 0;
+    background: #fff;
+}
+
+.company-info h2 {
+    text-align: center;
+    margin-bottom: 3rem;
+    font-size: 2.5rem;
+    color: #2c3e50;
+}
+
+.company-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+}
+
+.company-card {
+    background: #f8f9fa;
+    padding: 2rem;
+    border-radius: 12px;
+    text-align: center;
+    transition: transform 0.3s, box-shadow 0.3s;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.company-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+}
+
+.company-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.company-card h3 {
+    color: #2c3e50;
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+}
+
+.company-card p {
+    color: #555;
+    line-height: 1.8;
+    white-space: pre-line;
+}
+
 /* 商品セクション */
 .products {
     padding: 4rem 0;


### PR DESCRIPTION
## Summary
- 会社住所、連絡先、創業時間を表示する会社情報セクションを追加
- 人気商品セクションの下に配置
- 日本語と英語の多言語対応を実装
- レスポンシブ対応のカードレイアウトデザイン

## Test plan
- [x] ヘッダーの「会社情報」リンクをクリックすると会社情報セクションにスクロール
- [x] 会社住所、連絡先、創業時間が正しく表示される
- [x] 日本語/英語切り替えが正常に動作
- [x] レスポンシブデザインが各デバイスサイズで正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)